### PR TITLE
Fix Telegram alert delivery and restore automatic failover (supersedes #18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-06-11
+
+### Fixed
+- **Auto-failover trigger restored**: the trigger inadvertently removed during the
+  2.1.0 cleanup pass is reinstated, so HIGH-PRIORITY delinquency once again spawns
+  `execute_emergency_failover` when `auto_failover_enabled && vote_rpc_failures == 0`
+- **Telegram entity-parse failure**: dropped `parse_mode: "Markdown"` from the
+  `sendMessage` payload; validator labels containing unescaped Markdown
+  metacharacters (`_`, `*`, `` ` ``, `[`) no longer cause silent alert drops,
+  including HIGH-PRIORITY delinquency alerts that gate auto-failover operator
+  visibility
+- **Concurrent failover spawn**: the auto-failover spawn site now checks
+  `emergency_takeover_in_progress` before spawning `execute_emergency_failover`
+  and emits an Info-level `"Auto-failover spawn skipped: previous emergency
+  takeover still in progress"` log line when a prior takeover is still running,
+  preventing a second `tokio::spawn` from racing the in-flight one
+
+### Changed
+- **Background-task storage**: `Arc<RwLock<Vec<JoinHandle>>>` migrated to
+  `Arc<std::sync::Mutex<JoinSet>>` (`JoinSet` auto-aborts on drop, structurally
+  preventing the dup-cycle bug where re-invocations of `spawn_background_tasks`
+  could leave previous tasks running alongside the new ones). Boolean signaling
+  flags (`should_quit`, `emergency_takeover_in_progress`, `switch_confirmed`)
+  migrated from `Arc<RwLock<bool>>` to `Arc<AtomicBool>` (wait-free, eliminates
+  silent-drop under lock contention)
+
+### Added
+- **`SVS_SIMULATE_FAILOVER=<idx>` env var**: env-var-gated simulation that emits
+  a `🚨 SIMULATION DRY-RUN: ...` log marker on every poll tick without spawning
+  the real failover, allowing non-destructive end-to-end verification of the
+  auto-failover gate logic
+
 ## [2.1.0] - 2026-05-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4601,7 +4601,7 @@ dependencies = [
 
 [[package]]
 name = "solana-validator-switch"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-validator-switch"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 description = "Solana validator hot swap and failover CLI - 1-3 second hot swaps with automatic failover"
 authors = ["huisky <huiskylabs@gmail.com>"]

--- a/src/alert.rs
+++ b/src/alert.rs
@@ -198,10 +198,21 @@ impl AlertManager {
             telegram.bot_token
         );
 
+        // No parse_mode: deliver alert text as plain text. The previous
+        // `parse_mode: "Markdown"` caused Telegram to reject any message
+        // whose interpolated user-controlled field (validator label,
+        // node host, etc.) contained an unescaped Markdown
+        // metacharacter (`_`, `*`, `` ` ``, `[`) — for example a
+        // validator label like `Meshmap_Testnet` produced
+        // "Bad Request: can't parse entities" and the alert (including
+        // HIGH-PRIORITY delinquency alerts that gate auto-failover
+        // operator visibility) was silently dropped. The literal
+        // `*bold*` markers will now appear in the rendered message;
+        // restoring rich formatting safely requires escaping every
+        // user-controlled field, which is a separate follow-up.
         let payload = json!({
             "chat_id": telegram.chat_id,
             "text": message,
-            "parse_mode": "Markdown",
             "disable_web_page_preview": true
         });
 

--- a/src/auto_failover_tests.rs
+++ b/src/auto_failover_tests.rs
@@ -83,4 +83,236 @@ mod tests {
             "Should NOT trigger failover when RPC is failing"
         );
     }
+
+    /// Regression test for the deleted auto-failover trigger.
+    ///
+    /// Commit `c071354 review: apply mechanical cleanup pass` removed the
+    /// only call site of `execute_emergency_failover` while leaving the
+    /// function definition behind a stale `#[allow(dead_code)]`. The result
+    /// was that `auto_failover_enabled: true` in production silently did
+    /// nothing on the next delinquency event.
+    ///
+    /// This test asserts on the source text of `status_ui_v2.rs` so that
+    /// any future "cleanup" pass that removes the trigger again will
+    /// immediately fail the test suite — without needing to construct a
+    /// synthetic `AppState`/`UiState`/`AsyncSshPool` (which is many hundreds
+    /// of lines of boilerplate). The test is cheap insurance: it catches
+    /// deletions but does not catch logic regressions inside the trigger.
+    /// A future refactor that extracts the gate into a `pub(crate)` helper
+    /// can replace this with a behavioural test on the helper.
+    #[test]
+    fn test_auto_failover_trigger_call_site_still_present() {
+        let src = include_str!("commands/status_ui_v2.rs");
+
+        // Definition + at least one call site = at least 2 occurrences of
+        // `execute_emergency_failover(`. The definition counts as one. Any
+        // value < 2 means the call site has been deleted.
+        let occurrences = src.matches("execute_emergency_failover(").count();
+        assert!(
+            occurrences >= 2,
+            "execute_emergency_failover() has {} reference(s) in status_ui_v2.rs; expected at least 2 (1 definition + 1 call site). \
+             If this fails, the auto-failover trigger has been deleted again — see plan svs_restore_auto_failover_trigger.plan.md.",
+            occurrences
+        );
+
+        // The deleted code path emitted two distinctive log markers when
+        // the gate fired. The restored code preserves them verbatim so log
+        // greps from the previous era still match. Both must be present.
+        assert!(
+            src.contains("Auto-failover conditions met: vote_rpc_failures=0"),
+            "Expected 'Auto-failover conditions met' log line in status_ui_v2.rs; \
+             this is the first of two markers the gate emits and is required \
+             for log-grep continuity with the pre-c071354 era."
+        );
+        assert!(
+            src.contains("🚨 AUTO-FAILOVER: Initiating emergency takeover"),
+            "Expected '🚨 AUTO-FAILOVER: Initiating emergency takeover' log \
+             line in status_ui_v2.rs."
+        );
+
+        // The simulation env var must be wired to all three suppression
+        // sites. If any one of these strings disappears, simulation testing
+        // is broken and the operator cannot safely verify the gate without
+        // a real delinquency event.
+        assert!(
+            src.contains("SVS_SIMULATE_FAILOVER"),
+            "Expected SVS_SIMULATE_FAILOVER env var handling in status_ui_v2.rs."
+        );
+        assert!(
+            src.contains("🧪 SIMULATION: forcing node["),
+            "Expected '🧪 SIMULATION: forcing node[..]' force-delinquent marker."
+        );
+        assert!(
+            src.contains("🧪 SIMULATION: would have sent"),
+            "Expected '🧪 SIMULATION: would have sent' telegram-suppression marker."
+        );
+        assert!(
+            src.contains("🚨 SIMULATION DRY-RUN: auto-failover gate passed"),
+            "Expected '🚨 SIMULATION DRY-RUN' failover-suppression marker."
+        );
+    }
+
+    /// Documents the gating conditions for the auto-failover trigger.
+    ///
+    /// Mirrors the live boolean expression in the alerts_to_send loop:
+    ///     !is_backup
+    ///     && alert_config.enabled
+    ///     && alert_config.auto_failover_enabled
+    ///     && vote_rpc_failures == 0
+    /// If any of the four inputs is wrong, no failover should fire.
+    #[test]
+    fn test_auto_failover_gate_truth_table() {
+        fn gate(
+            is_backup: bool,
+            alerts_enabled: bool,
+            auto_failover_enabled: bool,
+            vote_rpc_failures: u32,
+        ) -> bool {
+            !is_backup && alerts_enabled && auto_failover_enabled && vote_rpc_failures == 0
+        }
+
+        // Happy path — fires.
+        assert!(gate(false, true, true, 0));
+
+        // Each input flipped in isolation must suppress.
+        assert!(!gate(true, true, true, 0), "backup should suppress");
+        assert!(
+            !gate(false, false, true, 0),
+            "alerts disabled should suppress"
+        );
+        assert!(
+            !gate(false, true, false, 0),
+            "auto_failover_enabled=false should suppress"
+        );
+        assert!(
+            !gate(false, true, true, 1),
+            "vote_rpc_failures>0 should suppress"
+        );
+        assert!(
+            !gate(false, true, true, 99),
+            "any vote_rpc_failures>0 should suppress"
+        );
+    }
+
+    /// Regression test for the dup-cycle root-cause fix.
+    ///
+    /// `spawn_background_tasks` is called once per `run_enhanced_ui`
+    /// invocation, and `run_enhanced_ui` is re-entered by
+    /// `show_enhanced_status_ui`'s outer loop after every manual switch.
+    /// Prior to the JoinSet refactor, each re-entry could leave the
+    /// previous (Loop A, Loop B) pair running and spawn a fresh pair on
+    /// top — after N switches, N+1 pairs would be racing on the same 20s
+    /// interval, producing log-burst dup-cycles that grew unboundedly
+    /// over time.
+    ///
+    /// The fix is structural: `background_tasks` is a
+    /// `tokio::task::JoinSet`, which auto-aborts every task it owns when
+    /// it is dropped. Since each new `EnhancedStatusApp` replaces the
+    /// previous one (and the previous one's `JoinSet` is dropped along
+    /// with it), the stale loops cannot outlive their owning app
+    /// instance. The Drop impl on `EnhancedStatusApp` is retained as an
+    /// explicit `JoinSet::abort_all()` call so the abort moment is
+    /// visible to a debugger and to source-code search.
+    ///
+    /// This test asserts on the source so that a future cleanup pass
+    /// that swaps the JoinSet back to a `Vec<JoinHandle>` (or removes
+    /// the Drop impl) will fail the test suite.
+    #[test]
+    fn test_background_tasks_aborted_on_respawn() {
+        let src = include_str!("commands/status_ui_v2.rs");
+
+        // ── Structural supervision: JoinSet ──
+        //
+        // `tokio::task::JoinSet` is the load-bearing primitive. Its
+        // `Drop` impl aborts every spawned task automatically, which is
+        // what prevents the dup-cycle bug. A regression to manual
+        // `Vec<JoinHandle>` management here re-opens the bug class.
+        assert!(
+            src.contains("tokio::task::JoinSet"),
+            "Expected `tokio::task::JoinSet` in status_ui_v2.rs. Without \
+             a JoinSet (or equivalent structured supervisor) the background \
+             loops are not aborted when their owning EnhancedStatusApp \
+             drops, which is the dup-cycle bug."
+        );
+        assert!(
+            src.contains("pub background_tasks: Arc<std::sync::Mutex<tokio::task::JoinSet"),
+            "Expected `pub background_tasks: Arc<std::sync::Mutex<tokio::task::JoinSet<...>>` \
+             field declaration on EnhancedStatusApp. The exact field type matters: \
+             `Arc<RwLock<Vec<JoinHandle>>>` does NOT auto-abort on drop and re-enables \
+             the dup-cycle bug class."
+        );
+
+        // ── Explicit Drop impl (defensive, makes the abort moment greppable) ──
+        assert!(
+            src.contains("impl Drop for EnhancedStatusApp"),
+            "Expected `impl Drop for EnhancedStatusApp` in status_ui_v2.rs. \
+             Even though `JoinSet::drop` would abort tasks implicitly, the \
+             explicit Drop impl makes the supervision discipline visible to \
+             readers and to source-code search."
+        );
+        assert!(
+            src.contains("tasks.abort_all()"),
+            "Expected Drop impl to call `tasks.abort_all()` on the JoinSet \
+             guard. This is the explicit abort that makes the supervision \
+             moment debugger-visible."
+        );
+
+        // ── Boolean signaling flags use AtomicBool, not RwLock<bool> ──
+        //
+        // RwLock<bool> with 50ms timeouts was silently dropping state
+        // updates under contention (bug class 3 in the concurrency-
+        // hardening plan). AtomicBool stores are wait-free so the
+        // contention path doesn't exist.
+        assert!(
+            src.contains("Arc<AtomicBool>"),
+            "Expected `Arc<AtomicBool>` in status_ui_v2.rs for the \
+             should_quit / emergency_takeover_in_progress / switch_confirmed \
+             signaling flags."
+        );
+        assert!(
+            src.contains("AtomicBool::new"),
+            "Expected `AtomicBool::new(...)` constructor calls in \
+             EnhancedStatusApp::new."
+        );
+
+        // ── Diagnostic counter retained ──
+        //
+        // After the JoinSet refactor, the counter still grows by 1 per
+        // manual switch, but distinct loop_ids in any 20s window should
+        // stay at exactly 2 (because the previous app's JoinSet aborted
+        // its tasks on drop). Regression tell: distinct loop_ids in a
+        // window > 2.
+        assert!(
+            src.contains("BACKGROUND_TASKS_SPAWN_COUNT"),
+            "The diagnostic counter should be retained after the fix."
+        );
+
+        // ── No silent-drop try_write inside refresh_vote_data_for_alerts ──
+        //
+        // The hot-path audit (Change 3 in the plan) converted every
+        // `try_write` site in the body of `refresh_vote_data_for_alerts`
+        // to a `write_lock_with_timeout` that logs a Warning on timeout.
+        // If a future change re-introduces `try_write()` inside this
+        // function body, the silent-drop pattern returns and bug class 3
+        // re-opens (vote_rpc_failures counter desyncs, alert suppressed
+        // when it shouldn't be, etc.).
+        let fn_start = src
+            .find("async fn refresh_vote_data_for_alerts(")
+            .expect("refresh_vote_data_for_alerts function must exist");
+        let after_start = &src[fn_start..];
+        // The next "/// View states for the UI" marker is right after
+        // the function's closing brace — see the source ordering near
+        // the top of status_ui_v2.rs.
+        let body_end = after_start
+            .find("/// View states for the UI")
+            .expect("View states marker must follow refresh_vote_data_for_alerts");
+        let body = &after_start[..body_end];
+        assert!(
+            !body.contains("try_write()"),
+            "`try_write()` reappeared inside refresh_vote_data_for_alerts. \
+             This re-opens the silent-drop bug class — converting it to \
+             `write_lock_with_timeout(&ui_state, 500).await` with a Warning \
+             log on the Err arm is the correct pattern."
+        );
+    }
 }

--- a/src/auto_failover_tests.rs
+++ b/src/auto_failover_tests.rs
@@ -314,5 +314,32 @@ mod tests {
              `write_lock_with_timeout(&ui_state, 500).await` with a Warning \
              log on the Err arm is the correct pattern."
         );
+
+        // ── Concurrent-spawn guard at the auto-failover spawn site ──
+        //
+        // A real failover runs for ~30-40s end-to-end while the poll
+        // tick fires every ~10-20s, so without an explicit
+        // `emergency_takeover_flag.load(...)` before the
+        // `tokio::spawn(execute_emergency_failover(...))` call site,
+        // the next tick can spawn a second failover that races the
+        // first. The 15-min alert cooldown was the indirect guard
+        // previously, which is brittle: changing the cooldown would
+        // silently re-introduce the race.
+        assert!(
+            src.contains("emergency_takeover_flag.load("),
+            "Expected `emergency_takeover_flag.load(...)` in status_ui_v2.rs \
+             at the auto-failover spawn site. Without an explicit load before \
+             the spawn, a second `tokio::spawn(execute_emergency_failover)` \
+             can race an in-flight takeover."
+        );
+        assert!(
+            src.contains(
+                "Auto-failover spawn skipped: previous emergency takeover still in progress"
+            ),
+            "Expected the `Auto-failover spawn skipped: ...` Info-level log \
+             marker at the auto-failover spawn site. Without this log line \
+             the operator cannot distinguish `gate did not fire` from `gate \
+             fired but spawn was suppressed`."
+        );
     }
 }

--- a/src/commands/status_ui_v2.rs
+++ b/src/commands/status_ui_v2.rs
@@ -22,7 +22,6 @@ async fn read_lock_with_timeout<T>(
 }
 
 /// Helper for acquiring write lock with timeout
-#[allow(dead_code)]
 async fn write_lock_with_timeout<T>(
     lock: &Arc<RwLock<T>>,
     timeout_ms: u64,
@@ -45,6 +44,7 @@ use ratatui::{
 };
 use std::fs::OpenOptions;
 use std::io::{self, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
@@ -56,16 +56,75 @@ use crate::alert::ComprehensiveAlertTracker;
 use std::sync::{Mutex, OnceLock};
 
 static ALERT_TRACKER: OnceLock<Mutex<ComprehensiveAlertTracker>> = OnceLock::new();
+
+// ── Diagnostics (added to investigate post-restart dup-cycle log bursts) ──
+
+/// Process-wide counter of how many times `spawn_background_tasks` has been
+/// invoked. If this ever exceeds 1 across a single process lifetime, it
+/// proves that the background loops are being re-spawned (suspected
+/// dup-cycle root cause). Bumped + logged on the very first line of
+/// `spawn_background_tasks`.
+static BACKGROUND_TASKS_SPAWN_COUNT: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Monotonic counter used to assign a unique `loop_id` to every spawned
+/// vote-refresh and node-status-refresh loop instance. The id is included
+/// in each per-tick log line so `grep "loop_id="` after restart reveals how
+/// many distinct loop instances are firing inside the same 20s window.
+static LOOP_INSTANCE_COUNTER: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+// ── Synthetic failover-simulation mode ──────────────────────────────────
+//
+// Set `SVS_SIMULATE_FAILOVER=<idx>` (e.g. `SVS_SIMULATE_FAILOVER=0`) at
+// process start to enable three suppressions for node index `<idx>`:
+//   1. Force that node to appear delinquent every tick (overrides
+//      `seconds_since_vote` to `threshold + 10` and treats vote-RPC
+//      failures as 0 for gate purposes).
+//   2. Skip the telegram alert send (the would-be send is logged instead,
+//      so the on-call channel is not spammed during testing).
+//   3. Skip the `execute_emergency_failover` spawn (the would-be call is
+//      logged instead, so the production validator is not actually swapped).
+//
+// All three suppressions are gated under the same single env var so an
+// operator cannot accidentally enable half of test mode.
+static SIMULATE_FAILOVER_IDX: OnceLock<Option<usize>> = OnceLock::new();
+
+fn simulate_failover_idx() -> Option<usize> {
+    *SIMULATE_FAILOVER_IDX.get_or_init(|| {
+        std::env::var("SVS_SIMULATE_FAILOVER")
+            .ok()
+            .and_then(|s| s.trim().parse::<usize>().ok())
+    })
+}
+
+/// Set of node indices for which the "forcing delinquent" log line has
+/// already been emitted in this process. Guarantees the line is logged
+/// once per node per process lifetime, not once per tick.
+static SIMULATION_FORCE_LOGGED: OnceLock<Mutex<std::collections::HashSet<usize>>> =
+    OnceLock::new();
+
+fn simulation_force_logged() -> &'static Mutex<std::collections::HashSet<usize>> {
+    SIMULATION_FORCE_LOGGED.get_or_init(|| Mutex::new(std::collections::HashSet::new()))
+}
+
 use crate::solana_rpc::{fetch_vote_account_data, ValidatorVoteData};
 use crate::types::{FailureTracker, NodeHealthStatus};
 use crate::{ssh::AsyncSshPool, AppState};
 
-/// Refresh vote data for all validators and send alerts
+/// Refresh vote data for all validators and send alerts.
+///
+/// `emergency_takeover_flag` is the shared `Arc<AtomicBool>` held by
+/// `EnhancedStatusApp` (`emergency_takeover_in_progress`). When the
+/// auto-failover gate fires inside this function, the spawned
+/// `execute_emergency_failover` task uses the flag to pause the UI
+/// render loop during the takeover.
 async fn refresh_vote_data_for_alerts(
     app_state: Arc<AppState>,
     ui_state: Arc<RwLock<UiState>>,
     log_sender: tokio::sync::mpsc::UnboundedSender<LogMessage>,
     alert_manager: Option<AlertManager>,
+    emergency_takeover_flag: Arc<AtomicBool>,
 ) {
     let mut new_vote_data = Vec::new();
 
@@ -91,8 +150,21 @@ async fn refresh_vote_data_for_alerts(
                 // same old vote slot does not prove the validator voted after
                 // the RPC outage. The taint is cleared later only when this
                 // fetch observes a NEW vote slot.
-                if let Ok(mut state) = ui_state.try_write() {
-                    state.rpc_failure_tracker[idx].record_success();
+                match write_lock_with_timeout(&ui_state, 500).await {
+                    Ok(mut state) => {
+                        state.rpc_failure_tracker[idx].record_success();
+                    }
+                    Err(e) => {
+                        let _ = log_sender.send(LogMessage {
+                            host: validator_log_host(&app_state, idx),
+                            message: format!(
+                                "ui_state write lock timed out while recording RPC success for validator {}: {}",
+                                idx, e
+                            ),
+                            timestamp: Instant::now(),
+                            level: LogLevel::Warning,
+                        });
+                    }
                 }
 
                 let _ = log_sender.send(LogMessage {
@@ -117,36 +189,48 @@ async fn refresh_vote_data_for_alerts(
                 // high-priority delinquency alert based on stale cached vote
                 // timestamps.
                 let (should_alert_rpc, consecutive_failures, seconds_since_first) =
-                    if let Ok(mut state) = ui_state.try_write() {
-                        state.rpc_failure_tracker[idx].record_failure(error_message.clone());
-                        if let Some(last_failure) = state.last_vote_rpc_failure_times.get_mut(idx) {
-                            *last_failure = Some(Instant::now());
+                    match write_lock_with_timeout(&ui_state, 500).await {
+                        Ok(mut state) => {
+                            state.rpc_failure_tracker[idx].record_failure(error_message.clone());
+                            if let Some(last_failure) = state.last_vote_rpc_failure_times.get_mut(idx) {
+                                *last_failure = Some(Instant::now());
+                            }
+                            let tracker = &state.rpc_failure_tracker[idx];
+                            let consecutive = tracker.consecutive_failures;
+                            let seconds = tracker.seconds_since_first_failure().unwrap_or(0);
+                            let threshold = app_state
+                                .config
+                                .alert_config
+                                .as_ref()
+                                .map(|c| c.rpc_failure_threshold_seconds)
+                                .unwrap_or(30);
+
+                            let should_alert = seconds >= threshold
+                                && {
+                                    let tracker_mutex = ALERT_TRACKER.get_or_init(|| {
+                                        Mutex::new(ComprehensiveAlertTracker::new(
+                                            app_state.validator_statuses.len(),
+                                            2,
+                                        ))
+                                    });
+                                    let mut tracker = tracker_mutex.lock().unwrap();
+                                    tracker.rpc_failure_tracker.should_send_alert(idx)
+                                };
+
+                            (should_alert, consecutive, seconds)
                         }
-                        let tracker = &state.rpc_failure_tracker[idx];
-                        let consecutive = tracker.consecutive_failures;
-                        let seconds = tracker.seconds_since_first_failure().unwrap_or(0);
-                        let threshold = app_state
-                            .config
-                            .alert_config
-                            .as_ref()
-                            .map(|c| c.rpc_failure_threshold_seconds)
-                            .unwrap_or(30);
-
-                        let should_alert = seconds >= threshold
-                            && {
-                                let tracker_mutex = ALERT_TRACKER.get_or_init(|| {
-                                    Mutex::new(ComprehensiveAlertTracker::new(
-                                        app_state.validator_statuses.len(),
-                                        2,
-                                    ))
-                                });
-                                let mut tracker = tracker_mutex.lock().unwrap();
-                                tracker.rpc_failure_tracker.should_send_alert(idx)
-                            };
-
-                        (should_alert, consecutive, seconds)
-                    } else {
-                        (false, 0, 0)
+                        Err(e) => {
+                            let _ = log_sender.send(LogMessage {
+                                host: validator_log_host(&app_state, idx),
+                                message: format!(
+                                    "ui_state write lock timed out while recording RPC failure for validator {}: {}",
+                                    idx, e
+                                ),
+                                timestamp: Instant::now(),
+                                level: LogLevel::Warning,
+                            });
+                            (false, 0, 0)
+                        }
                     };
 
                 if should_alert_rpc {
@@ -239,13 +323,26 @@ async fn refresh_vote_data_for_alerts(
                         match crate::validator_rpc::get_health(&*ssh_pool, &node, &ssh_key, rpc_port).await {
                             Ok(is_healthy) => {
                                 // Update UI state rpc health
-                                if let Ok(mut st) = ui_state_local.try_write() {
-                                    if let Some(pair) = st.rpc_health_data.get_mut(vidx) {
-                                        let rpc_status = if nidx == 0 { &mut pair.node_0 } else { &mut pair.node_1 };
-                                        rpc_status.is_healthy = is_healthy;
-                                        rpc_status.last_check = Some(Instant::now());
-                                        rpc_status.error_message = None;
-                                        rpc_status.failure_start = None;
+                                match write_lock_with_timeout(&ui_state_local, 500).await {
+                                    Ok(mut st) => {
+                                        if let Some(pair) = st.rpc_health_data.get_mut(vidx) {
+                                            let rpc_status = if nidx == 0 { &mut pair.node_0 } else { &mut pair.node_1 };
+                                            rpc_status.is_healthy = is_healthy;
+                                            rpc_status.last_check = Some(Instant::now());
+                                            rpc_status.error_message = None;
+                                            rpc_status.failure_start = None;
+                                        }
+                                    }
+                                    Err(e) => {
+                                        let _ = log_sender.send(LogMessage {
+                                            host: host_tag.clone(),
+                                            message: format!(
+                                                "ui_state write lock timed out while updating RPC health (healthy): {}",
+                                                e
+                                            ),
+                                            timestamp: Instant::now(),
+                                            level: LogLevel::Warning,
+                                        });
                                     }
                                 }
 
@@ -323,16 +420,29 @@ async fn refresh_vote_data_for_alerts(
                                 let error_text = e.to_string();
                                 let failure_start = {
                                     let mut start = None;
-                                    if let Ok(mut st) = ui_state_local.try_write() {
-                                        if let Some(pair) = st.rpc_health_data.get_mut(vidx) {
-                                            let rpc_status = if nidx == 0 { &mut pair.node_0 } else { &mut pair.node_1 };
-                                            rpc_status.is_healthy = false;
-                                            rpc_status.last_check = Some(Instant::now());
-                                            rpc_status.error_message = Some(error_text.clone());
-                                            if rpc_status.failure_start.is_none() {
-                                                rpc_status.failure_start = Some(Instant::now());
+                                    match write_lock_with_timeout(&ui_state_local, 500).await {
+                                        Ok(mut st) => {
+                                            if let Some(pair) = st.rpc_health_data.get_mut(vidx) {
+                                                let rpc_status = if nidx == 0 { &mut pair.node_0 } else { &mut pair.node_1 };
+                                                rpc_status.is_healthy = false;
+                                                rpc_status.last_check = Some(Instant::now());
+                                                rpc_status.error_message = Some(error_text.clone());
+                                                if rpc_status.failure_start.is_none() {
+                                                    rpc_status.failure_start = Some(Instant::now());
+                                                }
+                                                start = rpc_status.failure_start;
                                             }
-                                            start = rpc_status.failure_start;
+                                        }
+                                        Err(e) => {
+                                            let _ = log_sender.send(LogMessage {
+                                                host: host_tag.clone(),
+                                                message: format!(
+                                                    "ui_state write lock timed out while updating RPC health (unreachable): {}",
+                                                    e
+                                                ),
+                                                timestamp: Instant::now(),
+                                                level: LogLevel::Warning,
+                                            });
                                         }
                                     }
                                     start
@@ -421,8 +531,28 @@ async fn refresh_vote_data_for_alerts(
         }
     });
 
-    // Update UI state and check for delinquency alerts
-    if let Ok(mut state) = ui_state.try_write() {
+    // Update UI state and check for delinquency alerts. Hold the write
+    // lock for the duration of the check; a slow acquisition here
+    // surfaces as a loud Warning so a hidden writer cannot silently drop
+    // the alert pass (the silent-drop pattern that fail-open `try_write`
+    // enabled is what bug class 3 in the concurrency-hardening plan was
+    // about).
+    let mut state = match write_lock_with_timeout(&ui_state, 500).await {
+        Ok(g) => g,
+        Err(e) => {
+            let _ = log_sender.send(LogMessage {
+                host: "svs".to_string(),
+                message: format!(
+                    "ui_state write lock timed out at end of refresh_vote_data_for_alerts; skipping vote-data update and delinquency check this tick: {}",
+                    e
+                ),
+                timestamp: Instant::now(),
+                level: LogLevel::Warning,
+            });
+            return;
+        }
+    };
+    {
         // Update vote data
         let mut new_slot_times = Vec::new();
         let mut new_increments = Vec::new();
@@ -502,12 +632,29 @@ async fn refresh_vote_data_for_alerts(
             let tracker_mutex = ALERT_TRACKER.get().unwrap();
             let mut tracker = tracker_mutex.lock().unwrap();
 
-            // Collect alerts to send without holding locks while awaiting network calls
-            let mut alerts_to_send: Vec<(usize, bool, crate::types::NodeConfig, u64, u64, NodeHealthStatus, bool)> = Vec::new();
+            // Collect alerts to send without holding locks while awaiting network calls.
+            //
+            // Tuple fields (in order):
+            //   idx, is_backup, active_node, last_slot, seconds_since_vote,
+            //   node_health, is_active, vote_rpc_failures
+            //
+            // `vote_rpc_failures` is captured at push-time so the downstream
+            // auto-failover gate (which runs after we drop the `state` lock)
+            // can re-check the condition without re-acquiring the lock.
+            let mut alerts_to_send: Vec<(
+                usize,
+                bool,
+                crate::types::NodeConfig,
+                u64,
+                u64,
+                NodeHealthStatus,
+                bool,
+                u32,
+            )> = Vec::new();
 
             for (idx, last) in state.last_vote_slot_times.iter().enumerate() {
                 if let Some((last_slot, last_instant)) = last {
-                    let seconds_since_vote = last_instant.elapsed().as_secs();
+                    let real_seconds_since_vote = last_instant.elapsed().as_secs();
                     let threshold = app_state
                         .config
                         .alert_config
@@ -515,11 +662,51 @@ async fn refresh_vote_data_for_alerts(
                         .map(|c| c.delinquency_threshold_seconds)
                         .unwrap_or(30);
 
+                    // Simulation override: when SVS_SIMULATE_FAILOVER=<idx>
+                    // matches, force this node to appear delinquent for gate
+                    // evaluation. Real `last_vote_slot_times[idx]` is NOT
+                    // mutated; the override is read-only.
+                    let sim_idx = simulate_failover_idx();
+                    let simulation_active_for_idx = sim_idx == Some(idx);
+                    let seconds_since_vote = if simulation_active_for_idx {
+                        threshold + 10
+                    } else {
+                        real_seconds_since_vote
+                    };
+                    if simulation_active_for_idx {
+                        let mut logged = simulation_force_logged().lock().unwrap();
+                        if logged.insert(idx) {
+                            drop(logged);
+                            let host = if let Some(node_with_status) = app_state
+                                .validator_statuses[idx]
+                                .nodes_with_status
+                                .iter()
+                                .find(|n| n.status == crate::types::NodeStatus::Active)
+                            {
+                                node_with_status.node.host.clone()
+                            } else {
+                                app_state.validator_statuses[idx].nodes_with_status[0]
+                                    .node
+                                    .host
+                                    .clone()
+                            };
+                            let _ = log_sender.send(LogMessage {
+                                host: validator_log_host(&app_state, idx),
+                                message: format!(
+                                    "🧪 SIMULATION: forcing node[{}] {} to appear delinquent for gate evaluation (seconds_since_vote={}, vote_rpc_failures=0)",
+                                    idx, host, seconds_since_vote
+                                ),
+                                timestamp: Instant::now(),
+                                level: LogLevel::Warning,
+                            });
+                        }
+                    }
+
 
                     // Log delinquency check for debugging
                     let _ = log_sender.send(LogMessage {
                         host: validator_log_host(&app_state, idx),
-                            message: format!("[{}] Delinquency check: {} seconds without vote (threshold: {}s)", 
+                            message: format!("[{}] Delinquency check: {} seconds without vote (threshold: {}s){}",
                                 // Use active node label for identification
                                 if let Some(node_with_status) = app_state.validator_statuses[idx]
                                     .nodes_with_status
@@ -530,17 +717,32 @@ async fn refresh_vote_data_for_alerts(
                                 } else {
                                     app_state.validator_statuses[idx].nodes_with_status[0].node.label.as_str()
                                 },
-                                seconds_since_vote, threshold),
+                                real_seconds_since_vote, threshold,
+                                if simulation_active_for_idx {
+                                    format!(" [SIM forces {}s]", seconds_since_vote)
+                                } else {
+                                    String::new()
+                                }),
                         timestamp: Instant::now(),
                         level: LogLevel::Info,
                     });
 
                     if seconds_since_vote >= threshold {
-                        let vote_rpc_failures = state.rpc_failure_tracker[idx].consecutive_failures;
-                        let tainted_by_vote_rpc_failure = vote_rpc_failure_taints_last_vote_time(
-                            *last,
-                            state.last_vote_rpc_failure_times.get(idx).and_then(|v| *v),
-                        );
+                        // Under simulation we report vote-RPC as healthy so
+                        // the gate has the same shape as a real delinquency.
+                        let vote_rpc_failures = if simulation_active_for_idx {
+                            0
+                        } else {
+                            state.rpc_failure_tracker[idx].consecutive_failures
+                        };
+                        let tainted_by_vote_rpc_failure = if simulation_active_for_idx {
+                            false
+                        } else {
+                            vote_rpc_failure_taints_last_vote_time(
+                                *last,
+                                state.last_vote_rpc_failure_times.get(idx).and_then(|v| *v),
+                            )
+                        };
 
                         if vote_rpc_failures > 0 || tainted_by_vote_rpc_failure {
                             // The cluster RPC fetch path failed after the last observed
@@ -565,13 +767,23 @@ async fn refresh_vote_data_for_alerts(
                             continue;
                         }
 
-                        if should_send_high_priority_delinquency_alert(
-                            vote_rpc_failures,
-                            seconds_since_vote,
-                            threshold,
-                            &mut tracker.delinquency_tracker,
-                            idx,
-                        ) {
+                        // Under simulation, bypass the alert cooldown so the
+                        // pipeline (alerts_to_send -> failover-spawn) fires
+                        // on every tick. This is essential for the operator
+                        // to be able to observe the dry-run markers within a
+                        // short verification window.
+                        let should_enqueue = if simulation_active_for_idx {
+                            true
+                        } else {
+                            should_send_high_priority_delinquency_alert(
+                                vote_rpc_failures,
+                                seconds_since_vote,
+                                threshold,
+                                &mut tracker.delinquency_tracker,
+                                idx,
+                            )
+                        };
+                        if should_enqueue {
                             // proceed to enqueue alert
                         } else {
                             // Alert suppressed due to cooldown - log suppression with remaining time
@@ -613,7 +825,7 @@ async fn refresh_vote_data_for_alerts(
                         let is_backup = !is_active;
                         let node_health = state.validator_health[idx].clone();
 
-                        alerts_to_send.push((idx, is_backup, active_node, *last_slot, seconds_since_vote, node_health, is_active));
+                        alerts_to_send.push((idx, is_backup, active_node, *last_slot, seconds_since_vote, node_health, is_active, vote_rpc_failures));
                     }
                 }
             }
@@ -621,13 +833,17 @@ async fn refresh_vote_data_for_alerts(
             // Release tracker lock before awaiting network calls
             drop(tracker);
 
-            for (idx, is_backup, active_node, last_slot, seconds_since_vote, node_health, is_active) in alerts_to_send {
-                let alert_mgr = alert_mgr.clone();
-                let log_sender = log_sender.clone();
+            for (idx, is_backup, active_node, last_slot, seconds_since_vote, node_health, is_active, vote_rpc_failures) in alerts_to_send {
+                let alert_mgr_for_telegram = alert_mgr.clone();
+                let log_sender_for_telegram = log_sender.clone();
                 let identity = app_state.validator_statuses[idx].validator_pair.identity_pubkey.clone();
+                let host_for_log = validator_log_host(&app_state, idx);
+                let sim_idx = simulate_failover_idx();
+                let suppress_telegram = sim_idx == Some(idx);
+
                 // Pre-send log: record alert intent and priority
                 let _ = log_sender.send(LogMessage {
-                    host: validator_log_host(&app_state, idx),
+                    host: host_for_log.clone(),
                     message: format!(
                         "Preparing to send {} delinquency alert for {}: {}s without vote",
                         if is_backup { "LOW-PRIORITY" } else { "HIGH-PRIORITY" },
@@ -638,21 +854,39 @@ async fn refresh_vote_data_for_alerts(
                     level: LogLevel::Info,
                 });
 
+                let active_node_for_telegram = active_node.clone();
+                let host_for_telegram = host_for_log.clone();
                 tokio::spawn(async move {
+                    if suppress_telegram {
+                        let _ = log_sender_for_telegram.send(LogMessage {
+                            host: host_for_telegram,
+                            message: format!(
+                                "🧪 SIMULATION: would have sent {} telegram alert for {}: '{}s without vote' — send skipped because SVS_SIMULATE_FAILOVER={}",
+                                if is_backup { "LOW-PRIORITY" } else { "HIGH-PRIORITY" },
+                                active_node_for_telegram.label,
+                                seconds_since_vote,
+                                idx
+                            ),
+                            timestamp: Instant::now(),
+                            level: LogLevel::Warning,
+                        });
+                        return;
+                    }
+
                     let res = if is_backup {
-                        alert_mgr
+                        alert_mgr_for_telegram
                             .send_backup_delinquency_alert(
                                 &identity,
-                                &active_node.label,
+                                &active_node_for_telegram.label,
                                 last_slot,
                                 seconds_since_vote,
                             )
                             .await
                     } else {
-                        alert_mgr
+                        alert_mgr_for_telegram
                             .send_delinquency_alert_with_health(
                                 &identity,
-                                &active_node.label,
+                                &active_node_for_telegram.label,
                                 is_active,
                                 last_slot,
                                 seconds_since_vote,
@@ -662,21 +896,98 @@ async fn refresh_vote_data_for_alerts(
                     };
 
                     if let Err(e) = res {
-                        let _ = log_sender.send(LogMessage {
-                            host: active_node.label.clone(),
+                        let _ = log_sender_for_telegram.send(LogMessage {
+                            host: active_node_for_telegram.label.clone(),
                             message: format!("Failed to send {} delinquency alert: {}", if is_backup { "LOW-PRIORITY" } else { "HIGH-PRIORITY" }, e),
                             timestamp: Instant::now(),
                             level: LogLevel::Error,
                         });
                     } else {
-                        let _ = log_sender.send(LogMessage {
-                            host: active_node.label.clone(),
+                        let _ = log_sender_for_telegram.send(LogMessage {
+                            host: active_node_for_telegram.label.clone(),
                             message: format!("{} delinquency alert sent: {} seconds without vote", if is_backup { "LOW-PRIORITY" } else { "HIGH-PRIORITY" }, seconds_since_vote),
                             timestamp: Instant::now(),
                             level: LogLevel::Warning,
                         });
                     }
                 });
+
+                // ── Change 1: Auto-failover trigger ──
+                //
+                // Restores the trigger that was inadvertently removed in commit
+                // c071354 ("review: apply mechanical cleanup pass"). Mirrors the
+                // gating from the deleted code: HIGH-PRIORITY (active node
+                // delinquent) AND alert_config.enabled AND
+                // auto_failover_enabled AND vote_rpc_failures == 0.
+                if !is_backup {
+                    let auto_failover_enabled = app_state
+                        .config
+                        .alert_config
+                        .as_ref()
+                        .map(|c| c.enabled && c.auto_failover_enabled)
+                        .unwrap_or(false);
+
+                    if auto_failover_enabled && vote_rpc_failures == 0 {
+                        if sim_idx == Some(idx) {
+                            // Simulation dry-run: the gate evaluated to true,
+                            // but we do NOT spawn the real failover. The
+                            // emergency_takeover_flag is also intentionally
+                            // left false so the gate re-fires on the next
+                            // tick (operator can confirm the simulation is
+                            // sticky over multiple poll intervals).
+                            let _ = log_sender.send(LogMessage {
+                                host: host_for_log.clone(),
+                                message: format!(
+                                    "🚨 SIMULATION DRY-RUN: auto-failover gate passed for {} (vote_rpc_failures=0, simulated_delinquent={}s) — would have called execute_emergency_failover — spawn skipped because SVS_SIMULATE_FAILOVER={}",
+                                    active_node.label, seconds_since_vote, idx
+                                ),
+                                timestamp: Instant::now(),
+                                level: LogLevel::Error,
+                            });
+                        } else {
+                            // Live path: emit the two log markers the deleted
+                            // code used (preserved verbatim for log-grep
+                            // continuity), then spawn the failover. `alert_mgr`
+                            // is already `&AlertManager` from the enclosing
+                            // `if let Some(alert_mgr) = alert_manager.as_ref()`
+                            // scope, so we just clone it for the spawn.
+                            let _ = log_sender.send(LogMessage {
+                                host: host_for_log.clone(),
+                                message: format!(
+                                    "Auto-failover conditions met: vote_rpc_failures=0, delinquent for {} seconds",
+                                    seconds_since_vote
+                                ),
+                                timestamp: Instant::now(),
+                                level: LogLevel::Info,
+                            });
+                            let _ = log_sender.send(LogMessage {
+                                host: host_for_log.clone(),
+                                message: "🚨 AUTO-FAILOVER: Initiating emergency takeover".to_string(),
+                                timestamp: Instant::now(),
+                                level: LogLevel::Error,
+                            });
+
+                            let validator_status_for_failover =
+                                app_state.validator_statuses[idx].clone();
+                            let ssh_pool_for_failover = app_state.ssh_pool.clone();
+                            let detected_keys_for_failover =
+                                app_state.detected_ssh_keys.clone();
+                            let emergency_flag_for_failover =
+                                emergency_takeover_flag.clone();
+                            let am_for_failover = alert_mgr.clone();
+                            tokio::spawn(async move {
+                                execute_emergency_failover(
+                                    validator_status_for_failover,
+                                    am_for_failover,
+                                    ssh_pool_for_failover,
+                                    detected_keys_for_failover,
+                                    emergency_flag_for_failover,
+                                )
+                                .await;
+                            });
+                        }
+                    }
+                }
             }
         }
     }
@@ -743,25 +1054,25 @@ fn key_to_action(key: KeyEvent, current_view: &ViewState) -> Option<UiAction> {
     }
 }
 
-/// Process UI actions with timeouts to prevent blocking
+/// Process UI actions with timeouts to prevent blocking.
+///
+/// `should_quit` and `switch_confirmed` are `Arc<AtomicBool>` — wait-free
+/// atomic stores instead of `RwLock<bool>` with 50ms timeouts. The 50ms
+/// timeouts were silently dropping writes under contention, which was
+/// bug class 3 in the concurrency-hardening plan; atomics remove that
+/// failure mode entirely.
 async fn process_ui_action(
     action: UiAction,
     ui_state: &Arc<RwLock<UiState>>,
-    should_quit: &Arc<RwLock<bool>>,
+    should_quit: &Arc<AtomicBool>,
     view_state: &Arc<RwLock<ViewState>>,
     app_state: &Arc<AppState>,
-    switch_confirmed: &Arc<RwLock<bool>>,
+    switch_confirmed: &Arc<AtomicBool>,
     log_sender: &tokio::sync::mpsc::UnboundedSender<LogMessage>,
 ) -> Result<()> {
     match action {
         UiAction::Quit => {
-            // Use timeout for write lock
-            let quit_write =
-                tokio::time::timeout(Duration::from_millis(50), should_quit.write()).await;
-
-            if let Ok(mut quit) = quit_write {
-                *quit = true;
-            }
+            should_quit.store(true, Ordering::Release);
         }
         UiAction::CancelSwitch => {
             // Use timeout for write lock
@@ -782,17 +1093,9 @@ async fn process_ui_action(
             }
         }
         UiAction::ConfirmSwitch => {
-            // Use timeouts for both write locks
-            let switch_write =
-                tokio::time::timeout(Duration::from_millis(50), switch_confirmed.write()).await;
-
-            let quit_write =
-                tokio::time::timeout(Duration::from_millis(50), should_quit.write()).await;
-
-            if let (Ok(mut switch), Ok(mut quit)) = (switch_write, quit_write) {
-                *switch = true;
-                *quit = true;
-            }
+            // Atomic stores are wait-free; no timeout / contention path needed.
+            switch_confirmed.store(true, Ordering::Release);
+            should_quit.store(true, Ordering::Release);
         }
         UiAction::Refresh => {
             // Handle refresh with timeout
@@ -910,12 +1213,36 @@ pub struct EnhancedStatusApp {
     pub ssh_pool: Arc<AsyncSshPool>,
     pub ui_state: Arc<RwLock<UiState>>,
     pub log_sender: tokio::sync::mpsc::UnboundedSender<LogMessage>,
-    pub should_quit: Arc<RwLock<bool>>,
+    pub should_quit: Arc<AtomicBool>,
     pub view_state: Arc<RwLock<ViewState>>,
-    pub emergency_takeover_in_progress: Arc<RwLock<bool>>,
-    pub switch_confirmed: Arc<RwLock<bool>>,
-    pub background_tasks: Arc<RwLock<Vec<tokio::task::JoinHandle<()>>>>,
+    pub emergency_takeover_in_progress: Arc<AtomicBool>,
+    pub switch_confirmed: Arc<AtomicBool>,
+    pub background_tasks: Arc<std::sync::Mutex<tokio::task::JoinSet<()>>>,
     pub last_manual_refresh: Arc<RwLock<Instant>>,
+}
+
+/// Abort orphaned background tasks when the app is dropped.
+///
+/// `show_enhanced_status_ui` creates a fresh `EnhancedStatusApp` on every
+/// iteration of its outer loop (i.e. after every manual switch). With
+/// `tokio::task::JoinSet` storing the background loop handles, dropping
+/// the `JoinSet` already aborts every spawned task — this Drop impl is
+/// kept as an explicit call to `abort_all` so the abort moment is
+/// visible to a debugger and to source-code search, and so future
+/// readers can see the supervision discipline without having to know
+/// the implicit `Drop for JoinSet` semantics.
+impl Drop for EnhancedStatusApp {
+    fn drop(&mut self) {
+        // Acquire the sync Mutex non-blockingly: if a concurrent
+        // `spawn_background_tasks` call is currently holding the lock
+        // we accept the rare leak and rely on the implicit
+        // `Drop for JoinSet` abort that runs when the Arc's refcount
+        // hits zero. There is no useful recovery action available from
+        // a sync Drop.
+        if let Ok(mut tasks) = self.background_tasks.try_lock() {
+            tasks.abort_all();
+        }
+    }
 }
 
 /// UI State that can be shared across threads
@@ -1469,11 +1796,11 @@ impl EnhancedStatusApp {
             ssh_pool,
             ui_state,
             log_sender,
-            should_quit: Arc::new(RwLock::new(false)),
+            should_quit: Arc::new(AtomicBool::new(false)),
             view_state: Arc::new(RwLock::new(ViewState::Status)),
-            emergency_takeover_in_progress: Arc::new(RwLock::new(false)),
-            switch_confirmed: Arc::new(RwLock::new(false)),
-            background_tasks: Arc::new(RwLock::new(Vec::new())),
+            emergency_takeover_in_progress: Arc::new(AtomicBool::new(false)),
+            switch_confirmed: Arc::new(AtomicBool::new(false)),
+            background_tasks: Arc::new(std::sync::Mutex::new(tokio::task::JoinSet::new())),
             last_manual_refresh: Arc::new(RwLock::new(Instant::now() - Duration::from_secs(60))),
         })
     }
@@ -1513,8 +1840,44 @@ impl EnhancedStatusApp {
         }
     }
 
-    /// Spawn background tasks for data fetching
+    /// Spawn background tasks for data fetching.
+    ///
+    /// Each invocation pushes two long-running loops (vote-account poll
+    /// and node-status poll) into `self.background_tasks` (a
+    /// `tokio::task::JoinSet`). The `JoinSet` is the supervision boundary:
+    /// when the `EnhancedStatusApp` is dropped (which happens on every
+    /// outer-loop iteration of `show_enhanced_status_ui`), the `JoinSet`
+    /// drops and `tokio::task::JoinSet::drop` aborts every task it
+    /// contains. That is the structural fix for the dup-cycle class of
+    /// bug: stale loops cannot outlive their owning app instance.
+    ///
+    /// `BACKGROUND_TASKS_SPAWN_COUNT` and the per-loop `loop_id` markers
+    /// stay so post-restart log analysis can confirm exactly 2 distinct
+    /// `loop_id` values fire in any 20s window.
     pub fn spawn_background_tasks(&self) {
+        // ── Diagnostics (retained) ──
+        //
+        // Increment the process-wide spawn count and log it. Post-fix
+        // this counter still grows by 1 on every manual switch (because
+        // every switch produces a new `EnhancedStatusApp` that invokes
+        // us), but `JoinSet::drop` on the previous instance means the
+        // loop count stays at 2 instead of growing unboundedly. If
+        // post-fix logs ever show count > 1 paired with > 2 distinct
+        // `loop_id` values within a single 20s window, the fix has
+        // regressed.
+        let spawn_count = BACKGROUND_TASKS_SPAWN_COUNT
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
+        let _ = self.log_sender.send(LogMessage {
+            host: "svs".to_string(),
+            message: format!(
+                "spawn_background_tasks invoked (count = {})",
+                spawn_count
+            ),
+            timestamp: Instant::now(),
+            level: LogLevel::Info,
+        });
+
         let vote_account_poll_interval_seconds =
             vote_account_poll_interval_seconds(self.app_state.config.alert_config.as_ref());
         let node_status_poll_interval_seconds =
@@ -1523,7 +1886,31 @@ impl EnhancedStatusApp {
         let ui_state_for_vote_refresh = Arc::clone(&self.ui_state);
         let app_state_for_vote_refresh = Arc::clone(&self.app_state);
         let log_sender_for_vote_refresh = self.log_sender.clone();
-        tokio::spawn(async move {
+        let emergency_flag_for_vote_refresh =
+            Arc::clone(&self.emergency_takeover_in_progress);
+        let loop_a_id = LOOP_INSTANCE_COUNTER
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
+        let log_sender_for_loop_a_ticks = self.log_sender.clone();
+
+        let ui_state_for_node_refresh = Arc::clone(&self.ui_state);
+        let app_state_for_node_refresh = Arc::clone(&self.app_state);
+        let log_sender_for_node_refresh = self.log_sender.clone();
+        let loop_b_id = LOOP_INSTANCE_COUNTER
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
+        let log_sender_for_loop_b_ticks = self.log_sender.clone();
+
+        // Acquire the JoinSet lock once and spawn both loops into it.
+        // `JoinSet::spawn` is sync and fast (it stores a future + handle
+        // into an internal Vec), so the sync Mutex is correct here and
+        // the lock is released immediately after both spawns complete.
+        let mut tasks = self
+            .background_tasks
+            .lock()
+            .expect("background_tasks Mutex poisoned");
+
+        tasks.spawn(async move {
             let mut interval = interval(Duration::from_secs(vote_account_poll_interval_seconds));
             interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
@@ -1536,20 +1923,27 @@ impl EnhancedStatusApp {
 
             loop {
                 interval.tick().await;
+                // Per-tick loop_id marker so post-restart log analysis can
+                // count distinct loop instances within a single 20s poll
+                // window. Cheap (one log send per tick).
+                let _ = log_sender_for_loop_a_ticks.send(LogMessage {
+                    host: "svs".to_string(),
+                    message: format!("Loop A tick (loop_id={})", loop_a_id),
+                    timestamp: Instant::now(),
+                    level: LogLevel::Info,
+                });
                 refresh_vote_data_for_alerts(
                     app_state_for_vote_refresh.clone(),
                     ui_state_for_vote_refresh.clone(),
                     log_sender_for_vote_refresh.clone(),
                     alert_manager.clone(),
+                    emergency_flag_for_vote_refresh.clone(),
                 )
                 .await;
             }
         });
 
-        let ui_state_for_node_refresh = Arc::clone(&self.ui_state);
-        let app_state_for_node_refresh = Arc::clone(&self.app_state);
-        let log_sender_for_node_refresh = self.log_sender.clone();
-        tokio::spawn(async move {
+        tasks.spawn(async move {
             let mut interval = interval(Duration::from_secs(node_status_poll_interval_seconds));
             // Don't try to "catch up" on missed ticks. If the previous refresh
             // took longer than the configured interval, wait for the next
@@ -1559,15 +1953,29 @@ impl EnhancedStatusApp {
 
             loop {
                 interval.tick().await;
+                let _ = log_sender_for_loop_b_ticks.send(LogMessage {
+                    host: "svs".to_string(),
+                    message: format!("Loop B tick (loop_id={})", loop_b_id),
+                    timestamp: Instant::now(),
+                    level: LogLevel::Info,
+                });
 
-                // Skip if already refreshing
+                // Pre-check to skip wasted work if a refresh is already in
+                // flight. Benign on `try_read` failure: if we can't get
+                // the read, we just fall through and start another
+                // refresh — the inner spawn below merges-or-skips
+                // correctly. No silent state drop here.
                 if let Ok(state) = ui_state_for_node_refresh.try_read() {
                     if state.is_refreshing {
                         continue;
                     }
                 }
 
-                // Mark as refreshing
+                // Mark-as-refreshing. Benign on `try_write` failure: if
+                // we can't get the write, we don't mark — the next tick
+                // will try again 10s later. No silent state drop with
+                // observable consequence (the worst case is one wasted
+                // refresh on the next tick).
                 if let Ok(mut state) = ui_state_for_node_refresh.try_write() {
                     state.last_refresh_time = Instant::now();
                     state.is_refreshing = true;
@@ -1804,7 +2212,9 @@ pub async fn run_enhanced_ui(app: &mut EnhancedStatusApp) -> Result<bool> {
     terminal.clear()?;
     terminal.hide_cursor()?;
 
-    // Spawn background tasks
+    // Spawn background tasks (aborts any handles left over from a previous
+    // `run_enhanced_ui` invocation so manual switches don't accumulate
+    // orphan loops).
     app.spawn_background_tasks();
 
     // Create a channel for keyboard events
@@ -1874,27 +2284,13 @@ pub async fn run_enhanced_ui(app: &mut EnhancedStatusApp) -> Result<bool> {
                 .await?;
         }
 
-        // Check for quit signal with timeout to prevent blocking
-        let quit_check =
-            tokio::time::timeout(Duration::from_millis(1), app.should_quit.read()).await;
-
-        if let Ok(should_quit) = quit_check {
-            if *should_quit {
-                break;
-            }
+        // Check for quit signal. Atomic load is wait-free; no timeout needed.
+        if app.should_quit.load(Ordering::Acquire) {
+            break;
         }
 
-        // Check if emergency takeover is in progress with timeout
-        let emergency_check = tokio::time::timeout(
-            Duration::from_millis(1),
-            app.emergency_takeover_in_progress.read(),
-        )
-        .await;
-
-        let emergency_in_progress = match emergency_check {
-            Ok(guard) => *guard,
-            Err(_) => false, // Assume no emergency if we can't check
-        };
+        // Check if emergency takeover is in progress. Atomic load is wait-free.
+        let emergency_in_progress = app.emergency_takeover_in_progress.load(Ordering::Acquire);
 
         if emergency_in_progress && !emergency_mode {
             // Just entering emergency mode - cleanup terminal
@@ -1961,9 +2357,8 @@ pub async fn run_enhanced_ui(app: &mut EnhancedStatusApp) -> Result<bool> {
     std::io::stdout().flush()?;
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    // Return whether switch was confirmed
-    let switch_confirmed_result = read_lock_with_timeout(&app.switch_confirmed, 100).await;
-    Ok(switch_confirmed_result.map(|guard| *guard).unwrap_or(false))
+    // Return whether switch was confirmed. Atomic load is wait-free.
+    Ok(app.switch_confirmed.load(Ordering::Acquire))
 }
 
 // Note: handle_key_event has been replaced by the action-based system
@@ -3199,14 +3594,26 @@ fn draw_footer(f: &mut ratatui::Frame, area: Rect, ui_state: &UiState, app_state
     f.render_widget(footer, area);
 }
 
-/// Execute emergency failover for a validator
-#[allow(dead_code)] // This is called from tokio::spawn
+/// Execute emergency failover for a validator.
+///
+/// Called from `refresh_vote_data_for_alerts` when the auto-failover gate
+/// fires (HIGH-PRIORITY delinquency + vote_rpc_failures == 0 + alert_config
+/// enabled + auto_failover_enabled). The call site spawns this function via
+/// `tokio::spawn` so the alert-send loop continues running while the
+/// takeover executes.
+///
+/// `emergency_takeover_flag` is the shared `Arc<AtomicBool>` from
+/// `EnhancedStatusApp::emergency_takeover_in_progress`; this function
+/// flips it to `true` while the takeover is in flight (to pause UI
+/// rendering) and back to `false` after the takeover completes. Atomic
+/// stores are wait-free so the flag-flip never contends with the UI
+/// render loop's load.
 async fn execute_emergency_failover(
     validator_status: crate::ValidatorStatus,
     alert_manager: AlertManager,
     ssh_pool: Arc<crate::ssh::AsyncSshPool>,
     detected_ssh_keys: std::collections::HashMap<String, String>,
-    emergency_takeover_flag: Arc<RwLock<bool>>,
+    emergency_takeover_flag: Arc<AtomicBool>,
 ) {
     // Find active and standby nodes
     let (active_node, standby_node) = match (
@@ -3254,7 +3661,7 @@ async fn execute_emergency_failover(
     }
 
     // Set the emergency takeover flag to suspend UI rendering
-    *emergency_takeover_flag.write().await = true;
+    emergency_takeover_flag.store(true, Ordering::Release);
 
     // Wait a moment for the UI to stop rendering and cleanup terminal
     tokio::time::sleep(Duration::from_millis(300)).await;
@@ -3276,7 +3683,7 @@ async fn execute_emergency_failover(
     tokio::time::sleep(Duration::from_secs(3)).await;
 
     // Clear the emergency takeover flag to resume UI
-    *emergency_takeover_flag.write().await = false;
+    emergency_takeover_flag.store(false, Ordering::Release);
 }
 
 /// Draw the switch UI
@@ -4529,9 +4936,15 @@ pub async fn show_enhanced_status_ui(app_state: &AppState) -> Result<()> {
         }
 
         // Execute the switch
-        // Sync the UI's selected validator index to app_state before switch
-        // This ensures we switch the validator the user was viewing, not the default
-        if let Ok(ui_state_guard) = app.ui_state.try_read() {
+        // Sync the UI's selected validator index to app_state before switch.
+        // This ensures we switch the validator the user was viewing, not
+        // the default. We're in an async context just after
+        // `run_enhanced_ui` returned and before the next iteration, so
+        // `.read().await` is fine — there is no render-loop hot-path
+        // constraint here, and the silent-drop pattern of `try_read`
+        // could leave the switch operating on a stale index.
+        {
+            let ui_state_guard = app.ui_state.read().await;
             current_app_state.selected_validator_index = ui_state_guard.selected_validator_index;
         }
 

--- a/src/commands/status_ui_v2.rs
+++ b/src/commands/status_ui_v2.rs
@@ -927,7 +927,19 @@ async fn refresh_vote_data_for_alerts(
                         .map(|c| c.enabled && c.auto_failover_enabled)
                         .unwrap_or(false);
 
-                    if auto_failover_enabled && vote_rpc_failures == 0 {
+                    // Concurrent-spawn guard. A real failover runs for
+                    // ~30-40s end-to-end; without this load the next
+                    // poll tick (every ~10-20s) would `tokio::spawn` a
+                    // second `execute_emergency_failover` while the
+                    // first is still in flight, racing two takeovers
+                    // against each other. The 15-min alert cooldown
+                    // was the indirect guard previously, which is
+                    // brittle: a future cooldown change would silently
+                    // re-introduce the race.
+                    let already_in_progress =
+                        emergency_takeover_flag.load(Ordering::Acquire);
+
+                    if !already_in_progress && auto_failover_enabled && vote_rpc_failures == 0 {
                         if sim_idx == Some(idx) {
                             // Simulation dry-run: the gate evaluated to true,
                             // but we do NOT spawn the real failover. The
@@ -986,6 +998,20 @@ async fn refresh_vote_data_for_alerts(
                                 .await;
                             });
                         }
+                    } else if already_in_progress && auto_failover_enabled && vote_rpc_failures == 0 {
+                        // Distinguishes "gate did not fire" from "gate
+                        // fired but spawn was suppressed" in the log.
+                        // Only logs when the gate would otherwise have
+                        // fired (auto_failover_enabled && vote_rpc_failures == 0),
+                        // not on every poll tick.
+                        let _ = log_sender.send(LogMessage {
+                            host: host_for_log.clone(),
+                            message:
+                                "Auto-failover spawn skipped: previous emergency takeover still in progress"
+                                    .to_string(),
+                            timestamp: Instant::now(),
+                            level: LogLevel::Info,
+                        });
                     }
                 }
             }


### PR DESCRIPTION
This PR replaces #18 with a clean, reviewable diff (6 files / +893 / −152 vs. 68 files / +21871 / −2467) and addresses the four review comments inline.

### Three commits, each independently buildable

- **`1f678dd` — concurrency: switch to JoinSet + AtomicBool, restore auto-failover trigger.**
  Restores the auto-failover trigger inadvertently dropped in `c071354`. Migrates
  `background_tasks` to `Arc<std::sync::Mutex<JoinSet>>` (auto-aborts on drop,
  structurally prevents the dup-cycle bug class). Migrates `should_quit` /
  `emergency_takeover_in_progress` / `switch_confirmed` to `Arc<AtomicBool>`
  (wait-free, eliminates silent-drop under contention). Adds the
  `SVS_SIMULATE_FAILOVER=<idx>` env-var-gated dry-run for non-destructive
  end-to-end verification. Adds three regression tests.

- **`b6cfadd` — alert: drop Telegram parse_mode.**
  Removes `parse_mode: "Markdown"` from `sendMessage`. Validator labels with
  unescaped Markdown metacharacters (`_`, `*`, `` ` ``, `[`) were causing
  Telegram to reject the payload and silently drop the alert — including
  HIGH-PRIORITY delinquency alerts that gate auto-failover operator visibility.

- **`3af3dae` — concurrency: guard auto-failover spawn; bump to 2.1.1.**
  Adds an explicit `emergency_takeover_flag.load(Ordering::Acquire)` before
  the `tokio::spawn(execute_emergency_failover)` site, with an Info-level
  "Auto-failover spawn skipped" log marker on the suppressed path. Bumps
  Cargo.toml to 2.1.1 and adds the corresponding CHANGELOG entry.

### How each review comment from PR #18 is addressed

| # | Comment | Resolution |
|---|---|---|
| 1 | "CI removed clippy" (`.github/workflows/ci.yml:29`) | **Structural — no change in this PR.** PR #18's diff against `ci.yml` was an artifact of an old merge base (`f8f916f` from v1.0.5). On `upstream/main`, `ci.yml` (blob `a45a821`) is byte-identical to `Julianzs:main`'s `ci.yml`. Rebasing onto `upstream/main` eliminates the spurious diff. |
| 2 | "CI removed cargo audit" (`.github/workflows/ci.yml:61`) | Same root cause as #1. Eliminated by the rebase. |
| 3 | "Cargo.toml downgrade `2.1.0` → `2.0.6`" | Bumped to **2.1.1** in `3af3dae`. |
| 4 | "Concurrent failover spawns not guarded" (`src/commands/status_ui_v2.rs:930`) | Addressed in `3af3dae`: explicit `emergency_takeover_flag.load()` before the spawn, plus an Info log on the suppressed path so the operator can distinguish "gate did not fire" from "gate fired but spawn was suppressed". |

### Verification

- `cargo build --release` — clean (only the pre-existing `solana-client v1.18.26` future-incompat note)
- `cargo test --release` — 115 unit + 10 integration tests pass, including two new
  source-scan assertions in `test_background_tasks_aborted_on_respawn` that catch
  future regressions of the guard.
- Binary `strings target/release/svs | grep` confirms all SIMULATION / AUTO-FAILOVER
  markers plus the new "Auto-failover spawn skipped" log line are present.
